### PR TITLE
It is better to use the repository field in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ categories = ["command-line-utilities", "command-line-interface"]
 keywords = ["xargs", "streaming", "cli"]
 authors = ["Yuta Hinokuma <yuta.hinokuma725@gmail.com>"]
 readme = "README.md"
-homepage = "https://github.com/higumachan/sargs-rs/tree/main"
+repository = "https://github.com/higumachan/sargs-rs"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
To allow [Crates.io](https://crates.io/) , [lib.rs](https://lib.rs/) and the [Rust Digger](https://rust-digger.code-maven.com/) to link to it. See [the manifest](https://doc.rust-lang.org/cargo/reference/manifest.html#the-repository-field) for the explanation.